### PR TITLE
Fix gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,13 @@ intellij {
 }
 
 group 'net.egork'
-version '4.4.16'
+version '4.4.17'
 
 patchPluginXml {
     changeNotes """
       Add change notes here.<br>
       <em>most HTML tags may be used</em>"""
+    untilBuild "*.*"
 }
 
 dependencies {


### PR DESCRIPTION
Hi, I fixed two problems with gradle file.

# Bump version to 4.4.17
v4.4.17 is already released, isn't it?

# Patch plugin xml to remove untilBuild attribute
Gradle automatically generates Plugin XML file with `<idea-version since-build="182.4892" until-build="182.*"/>`.

Therefore current release doesn't work with IDEA 2018.3