### PR TITLE
Add JWS directory option for TopCoder Arena

### DIFF
--- a/src/main/java/net/egork/chelper/ProjectData.java
+++ b/src/main/java/net/egork/chelper/ProjectData.java
@@ -24,7 +24,7 @@ import java.util.Properties;
 public class ProjectData {
     public static final ProjectData DEFAULT = new ProjectData(
         "java.util.Scanner", "java.io.PrintWriter", "java.,javax.,com.sun.".split(","), "output", "",
-        "archive/unsorted", "main", "lib/test", false, false, true, false);
+        "archive/unsorted", "main", "lib/test", "", false, false, true, false);
 
     public final String inputClass;
     public final String outputClass;
@@ -34,12 +34,13 @@ public class ProjectData {
     public final String archiveDirectory;
     public final String defaultDirectory;
     public final String testDirectory;
+    public final String jwsDirectory;
     public final boolean enableUnitTests;
     public final boolean failOnIntegerOverflowForNewTasks;
     public final boolean smartTesting;
     public final boolean extensionProposed;
 
-    public ProjectData(String inputClass, String outputClass, String[] excludedPackages, String outputDirectory, String author, String archiveDirectory, String defaultDirectory, String testDirectory, boolean enableUnitTests, boolean failOnIntegerOverflowForNewTasks, boolean smartTesting, boolean extensionProposed) {
+    public ProjectData(String inputClass, String outputClass, String[] excludedPackages, String outputDirectory, String author, String archiveDirectory, String defaultDirectory, String testDirectory, String jwsDirectory, boolean enableUnitTests, boolean failOnIntegerOverflowForNewTasks, boolean smartTesting, boolean extensionProposed) {
         this.extensionProposed = extensionProposed;
         this.inputClass = inputClass.trim();
         this.outputClass = outputClass.trim();
@@ -49,6 +50,7 @@ public class ProjectData {
         this.archiveDirectory = archiveDirectory.trim();
         this.defaultDirectory = defaultDirectory.trim();
         this.testDirectory = testDirectory.trim();
+        this.jwsDirectory = jwsDirectory;
         this.enableUnitTests = enableUnitTests;
         this.failOnIntegerOverflowForNewTasks = failOnIntegerOverflowForNewTasks;
         this.smartTesting = smartTesting;
@@ -63,6 +65,7 @@ public class ProjectData {
         archiveDirectory = properties.getProperty("archiveDirectory", DEFAULT.archiveDirectory);
         defaultDirectory = properties.getProperty("defaultDirectory", DEFAULT.defaultDirectory);
         testDirectory = properties.getProperty("testDirectory", DEFAULT.testDirectory);
+        jwsDirectory = properties.getProperty("jwsDirectory", DEFAULT.jwsDirectory);
         enableUnitTests = Boolean.valueOf(properties.getProperty("enableUnitTests", Boolean.toString(DEFAULT.enableUnitTests)));
         failOnIntegerOverflowForNewTasks = Boolean.valueOf(properties.getProperty("failOnIntegerOverflowForNewTasks", Boolean.toString(DEFAULT.enableUnitTests)));
         smartTesting = Boolean.valueOf(properties.getProperty("smartTesting", Boolean.toString(DEFAULT.smartTesting)));
@@ -101,6 +104,7 @@ public class ProjectData {
                 properties.setProperty("archiveDirectory", archiveDirectory);
                 properties.setProperty("defaultDirectory", defaultDirectory);
                 properties.setProperty("testDirectory", testDirectory);
+                properties.setProperty("jwsDirectory", jwsDirectory);
                 properties.setProperty("enableUnitTests", Boolean.toString(enableUnitTests));
                 properties.setProperty("failOnIntegerOverflowForNewTasks", Boolean.toString(failOnIntegerOverflowForNewTasks));
                 properties.setProperty("smartTesting", Boolean.toString(smartTesting));
@@ -138,7 +142,7 @@ public class ProjectData {
 
     public void completeExtensionProposal(Project project) {
         ProjectData newData = new ProjectData(inputClass, outputClass, excludedPackages, outputDirectory, author,
-            archiveDirectory, defaultDirectory, testDirectory, enableUnitTests, failOnIntegerOverflowForNewTasks, smartTesting, true);
+            archiveDirectory, defaultDirectory, testDirectory, jwsDirectory, enableUnitTests, failOnIntegerOverflowForNewTasks, smartTesting, true);
         newData.save(project);
         ProjectUtils.putProjectData(project, newData);
     }
@@ -159,12 +163,13 @@ public class ProjectData {
             Objects.equals(author, that.author) &&
             Objects.equals(archiveDirectory, that.archiveDirectory) &&
             Objects.equals(defaultDirectory, that.defaultDirectory) &&
-            Objects.equals(testDirectory, that.testDirectory);
+            Objects.equals(testDirectory, that.testDirectory) &&
+            Objects.equals(jwsDirectory, that.jwsDirectory);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(inputClass, outputClass, outputDirectory, author, archiveDirectory, defaultDirectory, testDirectory, enableUnitTests, failOnIntegerOverflowForNewTasks, smartTesting, extensionProposed);
+        int result = Objects.hash(inputClass, outputClass, outputDirectory, author, archiveDirectory, defaultDirectory, testDirectory, jwsDirectory, enableUnitTests, failOnIntegerOverflowForNewTasks, smartTesting, extensionProposed);
         result = 31 * result + Arrays.hashCode(excludedPackages);
         return result;
     }

--- a/src/main/java/net/egork/chelper/actions/TopCoderAction.java
+++ b/src/main/java/net/egork/chelper/actions/TopCoderAction.java
@@ -42,7 +42,12 @@ public class TopCoderAction extends AnAction {
         String arenaFileName = createArenaJar();
         if (arenaFileName == null)
             return;
-        String javaExecutable = System.getProperty("java.home") + File.separator + "bin" + File.separator + "javaws";
+        String javaExecutable;
+        if ("".equals(ProjectUtils.getData(project).jwsDirectory)) {
+            javaExecutable = System.getProperty("java.home") + File.separator + "bin" + File.separator + "javaws";
+        } else {
+            javaExecutable = ProjectUtils.getData(project).jwsDirectory + File.separator + "javaws";
+        }
         try {
             new ProcessBuilder(javaExecutable, arenaFileName).start();
         } catch (IOException ex) {

--- a/src/main/java/net/egork/chelper/ui/DirectorySelector.java
+++ b/src/main/java/net/egork/chelper/ui/DirectorySelector.java
@@ -84,4 +84,8 @@ public class DirectorySelector extends JPanel {
     public String getText() {
         return textField.getText();
     }
+
+    public void setText(String text) {
+        textField.setText(text);
+    }
 }

--- a/src/main/java/net/egork/chelper/ui/ProjectDataDialog.java
+++ b/src/main/java/net/egork/chelper/ui/ProjectDataDialog.java
@@ -26,12 +26,15 @@ public class ProjectDataDialog extends JDialog {
     private final JCheckBox enableUnitTests;
     private final JCheckBox smartTesting;
     private final JCheckBox failOnIntegerOverflowForNewTasks;
+    private final JCheckBox useCustomJws;
     private final DirectorySelector testDirectory;
+    private final DirectorySelector jwsDirectory;
     private final ClassSelector inputClass;
     private final ClassSelector outputClass;
     private final JTextField excludePackages;
     private final JTextField author;
     private final JLabel testDirectoryLabel;
+    private final JLabel jwsDirectoryLabel;
     private final int width = new JTextField(20).getPreferredSize().width;
 
     public ProjectDataDialog(final Project project, ProjectData data) {
@@ -44,7 +47,9 @@ public class ProjectDataDialog extends JDialog {
         outputDirectory = new DirectorySelector(project, data.outputDirectory);
         enableUnitTests = new JCheckBox("Enable unit tests", data.enableUnitTests);
         failOnIntegerOverflowForNewTasks = new JCheckBox("Fail on integer overflow for new tasks", data.failOnIntegerOverflowForNewTasks);
+        useCustomJws = new JCheckBox("Specify JWS location for TopCoder Arena", !"".equals(data.jwsDirectory));
         testDirectory = new DirectorySelector(project, data.testDirectory);
+        jwsDirectory = new DirectorySelector(project, data.jwsDirectory);
         inputClass = new ClassSelector(project, data.inputClass);
         outputClass = new ClassSelector(project, data.outputClass);
         excludePackages = new JTextField(ProjectData.join(data.excludedPackages));
@@ -85,6 +90,10 @@ public class ProjectDataDialog extends JDialog {
         testDirectoryLabel = new JLabel("Test directory:");
         main.add(testDirectoryLabel);
         main.add(testDirectory);
+        main.add(useCustomJws);
+        jwsDirectoryLabel = new JLabel("JWS location:");
+        main.add(jwsDirectoryLabel);
+        main.add(jwsDirectory);
         main.add(new JLabel("Input class:"));
         main.add(inputClass);
         main.add(new JLabel("Output class:"));
@@ -102,6 +111,18 @@ public class ProjectDataDialog extends JDialog {
             public void actionPerformed(ActionEvent e) {
                 testDirectory.setVisible(enableUnitTests.isSelected());
                 testDirectoryLabel.setVisible(enableUnitTests.isSelected());
+                pack();
+            }
+        });
+        jwsDirectory.setVisible(useCustomJws.isSelected());
+        jwsDirectoryLabel.setVisible(useCustomJws.isSelected());
+        useCustomJws.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                jwsDirectory.setVisible(useCustomJws.isSelected());
+                jwsDirectoryLabel.setVisible(useCustomJws.isSelected());
+                if (!useCustomJws.isSelected()) {
+                    jwsDirectory.setText("");
+                }
                 pack();
             }
         });
@@ -141,7 +162,7 @@ public class ProjectDataDialog extends JDialog {
     }
 
     private void onChange() {
-        data = new ProjectData(inputClass.getText(), outputClass.getText(), excludePackages.getText().split(","), outputDirectory.getText(), author.getText(), archiveDirectory.getText(), defaultDirectory.getText(), testDirectory.getText(), enableUnitTests.isSelected(), failOnIntegerOverflowForNewTasks.isSelected(), smartTesting.isSelected(), true);
+        data = new ProjectData(inputClass.getText(), outputClass.getText(), excludePackages.getText().split(","), outputDirectory.getText(), author.getText(), archiveDirectory.getText(), defaultDirectory.getText(), testDirectory.getText(), jwsDirectory.getText(), enableUnitTests.isSelected(), failOnIntegerOverflowForNewTasks.isSelected(), smartTesting.isSelected(), true);
     }
 
     @Override


### PR DESCRIPTION
This solves EgorKulikov#73.

In an old implementation, `javaws` should be located at
```java
System.getProperty("java.home") + File.separator + "bin" + File.separator + "javaws"
```
and Arena cannot be launched if IDEA runtime doesn't come with JWS.

I made an option to tell where is `javaws` and prevent `No such file or directory` errors.

In my case, changing path to `/usr/bin/javaws` works well.
